### PR TITLE
Switched to request for doing HTTP request, fixes #2 and #4

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -10,9 +10,8 @@
 /**
  * Module dependencies
  */
-var http = require('http');
-var debug = require('debug')('node-redmine');
-var querystring = require('querystring');
+var request = require('request');
+var Url = require('url');
 
 ////////////////////////////////////////////////////////////////////////////////////
 /**
@@ -27,22 +26,21 @@ var querystring = require('querystring');
  * @param {String} port, Redmine port (defaults to 80)
  */
 function Redmine(host, config, port) {
-  if (!host) throw new Error('Invalidate hostname !');
+  if (!host) throw new Error('host not specified!');
 
-  if (typeof host !== 'string') throw new Error('hostname should be a String !');
+  if (typeof host === 'string') {
+    host = Url.parse(host);
+  } else if (typeof host !== 'object') {
+    throw new Error('host should be a string or url object!');
+  }
+  if (port) host.port = port;
 
-  if (!(config.apiKey || (config.username && config.password))) {
+  this._request = request.defaults({baseUrl: host.href});
+
+  if (!config || !(config.apiKey || (config.username && config.password))) {
     throw new Error('You should provide an API key or username & password !');
   }
-
-  if (config.format) {
-    if ('json' !== config.format && 'xml' !== config.format) throw new Error('Redmine REST API only supports json and xml !');
-  }
-
   this.config = config;
-  this.config.host = host;
-  this.config.port = port || 80;
-  this.config.format = 'json';
 }
 
 Redmine.prototype = {
@@ -52,12 +50,6 @@ Redmine.prototype = {
   },
   set apiKey(apiKey) {
     this.config.apiKey = apiKey;
-  },
-  get host() {
-    return this.config.host;
-  },
-  set host(host) {
-    this.config.host = host;
   },
   get username() {
     return this.config.username;
@@ -74,93 +66,38 @@ Redmine.prototype = {
 };
 
 /**
- * encodeURL
- */
-Redmine.prototype.encodeURL = function(path, params) {
-  if (path.slice(0, 1) != '/') path = '/' + path;
-
-  var query = querystring.stringify(params);
-  if (query) path = path + '?' + query;
-
-  return path;
-};
-
-/**
  * request - request url from Redmine
  */
 Redmine.prototype.request = function(method, path, params, callback) {
   var opts = {
-    host: this.config.host,
-    port: this.config.port,
-    path: method == 'GET' ? this.encodeURL(path, params) : path,
     method: method,
-    headers: {}
+    qs: method === 'GET' ? params : undefined,
+    data: method === 'PUT' || method === 'POST' ? params : undefined,
+    headers: {
+      'X-Redmine-Switch-User': this.config.impersonate // impersonate to a login user
+    },
+    // auth: { user: this.username, pass: this.password },
+    json: true
   };
 
-  // add auth for access redmine
   if (this.apiKey) {
     opts.headers['X-Redmine-API-Key'] = this.config.apiKey;
   } else if (this.username && this.password) {
-    opts.auth = this.username + ':' + this.password;
+    opts.auth = { username: this.username, password: this.password };
   } else {
     throw new Error('Neither api key nor username/password provided !');
   }
 
-  // impersonate to a login user
-  if (this.impersonate) {
-    opts.headers['X-Redmine-Switch-User'] = this.config.impersonate;
-  }
+  var req = this._request(path, opts, function(err, res, body) {
+    if (err) return callback(err);
 
-  var req = http.request(opts, function(res) {
-    //console.log(res);
     if (res.statusCode != 200 && res.statusCode != 201) {
-      callback('Server returns : ' + res.statusMessage + ' (' + String(res.statusCode) + ')', null);
-      callback = null;
-      return ;
+      return callback('Server returns : ' + res.statusMessage + ' (' + String(res.statusCode) + ')');
     }
 
-    var body = "";
-    res.setEncoding('utf8');
-    res.on('data', function (chunk) {
-      body += chunk;
-    });
-
-    res.on('end', function(e) {
-      var data;
-      if (body) {
-        data = JSON.parse(body);
-      } else {
-        data = {statusCode: res.statusCode, statusMessage: res.statusMessage };
-      }
-      callback(null, data);
-      callback = null;
-      return ;
-    });
+    return callback(null, body);
   });
-
-  req.on('error', function(err) {
-    callback(err, null);
-    callback = null;
-    return ;
-  });
-
-  if ('PUT' == method || 'POST' == method) {
-    // add post data for POST and PUT
-    var data = JSON.stringify(params);
-    req.setHeader('Content-Length', lengthInUtf8Bytes(data));
-    req.setHeader('Content-Type', this.config.format == 'json' ? 'application/json' : 'application/xml');
-    req.write(data);
-  }
-
-  req.end();
 };
-
-function lengthInUtf8Bytes(str) {
-  // Matches only the 10.. bytes that are non-initial characters in a multi-byte sequence.
-  var m = encodeURIComponent(str).match(/%[89ABab]/g);
-  return str.length + (m ? m.length : 0);
-}
-
 
 /////////////////////////////////////// REST API for issues (Stable) ///////////////////////////////////////
 /**
@@ -171,7 +108,7 @@ function lengthInUtf8Bytes(str) {
 Redmine.prototype.get_issue_by_id = function(id, params, callback) {
   if (typeof id !== 'number') throw new Error('Issue ID must be an integer above 0 !');
 
-  this.request('GET', '/issues/' + id + '.' + this.config.format, params, callback);
+  this.request('GET', '/issues/' + id + '.json', params, callback);
 };
 
 /**
@@ -179,7 +116,7 @@ Redmine.prototype.get_issue_by_id = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Issues#Showing-an-issue
  */
 Redmine.prototype.issues = function(params, callback) {
-  this.request('GET', '/issues' + '.' + this.config.format, params, callback);
+  this.request('GET', '/issues.json', params, callback);
 };
 
 /**
@@ -187,7 +124,7 @@ Redmine.prototype.issues = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Issues#Creating-an-issue
  */
 Redmine.prototype.create_issue = function(issue, callback) {
-  this.request('POST', '/issues.' + this.config.format, issue, callback);
+  this.request('POST', '/issues.json', issue, callback);
 };
 
 /**
@@ -195,7 +132,7 @@ Redmine.prototype.create_issue = function(issue, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Issues#Updating-an-issue
  */
 Redmine.prototype.update_issue = function(id, issue, callback) {
-  this.request('PUT', '/issues/' + id + '.' + this.config.format, issue, callback);
+  this.request('PUT', '/issues/' + id + '.json', issue, callback);
 };
 
 /**
@@ -203,7 +140,7 @@ Redmine.prototype.update_issue = function(id, issue, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Issues#Deleting-an-issue
  */
 Redmine.prototype.delete_issue = function(id, callback) {
-  this.request('DELETE', '/issues/' + id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/issues/' + id + '.json', {}, callback);
 };
 
 /**
@@ -213,7 +150,7 @@ Redmine.prototype.delete_issue = function(id, callback) {
 Redmine.prototype.add_watcher = function(id, params, callback) {
   if (!params.user_id) throw new Error('user_id (required): id of the user to add as a watcher !');
 
-  this.request('POST', '/issues/' + id + '/watchers.' + this.config.format, params, callback);
+  this.request('POST', '/issues/' + id + '/watchers.json', params, callback);
 };
 
 /**
@@ -221,7 +158,7 @@ Redmine.prototype.add_watcher = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Issues#Removing-a-watcher
  */
 Redmine.prototype.remove_watcher = function(issue_id, user_id, callback) {
-  this.request('DELETE', '/issues/' + issue_id + '/watchers/' + user_id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/issues/' + issue_id + '/watchers/' + user_id + '.json', {}, callback);
 };
 
 
@@ -231,7 +168,7 @@ Redmine.prototype.remove_watcher = function(issue_id, user_id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Projects#Listing-projects
  */
 Redmine.prototype.projects = function(params, callback) {
- this.request('GET', '/projects.' + this.config.format, params, callback);
+ this.request('GET', '/projects.json', params, callback);
 };
 
 /**
@@ -239,7 +176,7 @@ Redmine.prototype.projects = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Projects#Showing-a-project
  */
 Redmine.prototype.get_project_by_id = function(id, params, callback) {
- this.request('GET', '/projects/' + id + '.' + this.config.format, params, callback);
+ this.request('GET', '/projects/' + id + '.json', params, callback);
 };
 
 /**
@@ -247,7 +184,7 @@ Redmine.prototype.get_project_by_id = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Projects#Creating-a-project
  */
 Redmine.prototype.create_project = function(params, callback) {
- this.request('POST', '/projects.' + this.config.format, params, callback);
+ this.request('POST', '/projects.json', params, callback);
 };
 
 /**
@@ -255,7 +192,7 @@ Redmine.prototype.create_project = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Projects#Updating-a-project
  */
 Redmine.prototype.update_project = function(id, params, callback) {
- this.request('PUT', '/projects/' + id + '.' + this.config.format, params, callback);
+ this.request('PUT', '/projects/' + id + '.json', params, callback);
 };
 
 /**
@@ -263,7 +200,7 @@ Redmine.prototype.update_project = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Projects#Deleting-a-project
  */
 Redmine.prototype.delete_project = function(id, callback) {
- this.request('DELETE', '/projects/' + id + '.' + this.config.format, {}, callback);
+ this.request('DELETE', '/projects/' + id + '.json', {}, callback);
 };
 
 
@@ -273,7 +210,7 @@ Redmine.prototype.delete_project = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Users#GET
  */
 Redmine.prototype.users = function(params, callback) {
- this.request('GET', '/users.' + this.config.format, params, callback);
+ this.request('GET', '/users.json', params, callback);
 };
 
 /**
@@ -281,7 +218,7 @@ Redmine.prototype.users = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Users#GET-2
  */
 Redmine.prototype.get_user_by_id = function(id, params, callback) {
- this.request('GET', '/users/' + id + '.' + this.config.format, params, callback);
+ this.request('GET', '/users/' + id + '.json', params, callback);
 };
 
 /**
@@ -289,7 +226,7 @@ Redmine.prototype.get_user_by_id = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Users#GET-2
  */
 Redmine.prototype.current_user = function(params, callback) {
- this.request('GET', '/users/current.' + this.config.format, params, callback);
+ this.request('GET', '/users/current.json', params, callback);
 };
 
 /**
@@ -297,7 +234,7 @@ Redmine.prototype.current_user = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Users#POST
  */
 Redmine.prototype.create_user = function(params, callback) {
- this.request('POST', '/users.' + this.config.format, params, callback);
+ this.request('POST', '/users.json', params, callback);
 };
 
 /**
@@ -305,7 +242,7 @@ Redmine.prototype.create_user = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Users#PUT
  */
 Redmine.prototype.update_user = function(id, params, callback) {
- this.request('PUT', '/users/' + id + '.' + this.config.format, params, callback);
+ this.request('PUT', '/users/' + id + '.json', params, callback);
 };
 
 /**
@@ -313,7 +250,7 @@ Redmine.prototype.update_user = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Users#DELETE
  */
 Redmine.prototype.delete_user = function(id, callback) {
- this.request('DELETE', '/users/' + id + '.' + this.config.format, {}, callback);
+ this.request('DELETE', '/users/' + id + '.json', {}, callback);
 };
 
 
@@ -323,7 +260,7 @@ Redmine.prototype.delete_user = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries#Listing-time-entries
  */
 Redmine.prototype.time_entries = function(callback) {
-  this.request('GET', '/time_entries.' + this.config.format, {}, callback);
+  this.request('GET', '/time_entries.json', {}, callback);
 };
 
 /**
@@ -331,7 +268,7 @@ Redmine.prototype.time_entries = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries#Showing-a-time-entry
  */
 Redmine.prototype.get_time_entry_by_id = function(id, callback) {
-  this.request('GET', '/time_entries/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/time_entries/' + id + '.json', {}, callback);
 };
 
 /**
@@ -339,7 +276,7 @@ Redmine.prototype.get_time_entry_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries#Creating-a-time-entry
  */
 Redmine.prototype.create_time_entry = function(params, callback) {
-  this.request('POST', '/time_entries.' + this.config.format, params, callback);
+  this.request('POST', '/time_entries.json', params, callback);
 };
 
 /**
@@ -347,7 +284,7 @@ Redmine.prototype.create_time_entry = function(params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries#Updating-a-time-entry
  */
 Redmine.prototype.update_time_entry = function(id, params, callback) {
-  this.request('PUT', '/time_entries/' + id + '.' + this.config.format, params, callback);
+  this.request('PUT', '/time_entries/' + id + '.json', params, callback);
 };
 
 /**
@@ -355,7 +292,7 @@ Redmine.prototype.update_time_entry = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries#Deleting-a-time-entry
  */
 Redmine.prototype.delete_time_entry = function(id, callback) {
-  this.request('DELETE', '/time_entries/' + id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/time_entries/' + id + '.json', {}, callback);
 };
 
 
@@ -365,7 +302,7 @@ Redmine.prototype.delete_time_entry = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#GET
  */
 Redmine.prototype.membership_by_project_id = function(id, callback) {
-  this.request('GET', '/projects/' + id + '/memberships.' + this.config.format, {}, callback);
+  this.request('GET', '/projects/' + id + '/memberships.json', {}, callback);
 };
 
 /**
@@ -373,7 +310,7 @@ Redmine.prototype.membership_by_project_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#POST
  */
 Redmine.prototype.create_project_membership = function(id, params, callback) {
-  this.request('POST', '/projects/' + id + '/memberships.' + this.config.format, params, callback);
+  this.request('POST', '/projects/' + id + '/memberships.json', params, callback);
 };
 
 /**
@@ -381,7 +318,7 @@ Redmine.prototype.create_project_membership = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#GET-2
  */
 Redmine.prototype.project_membership_by_id = function(id, callback) {
-  this.request('GET', '/memberships/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/memberships/' + id + '.json', {}, callback);
 };
 
 /**
@@ -389,7 +326,7 @@ Redmine.prototype.project_membership_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#PUT
  */
 Redmine.prototype.update_project_membership = function(id, params, callback) {
-  this.request('PUT', '/memberships/' + id + '.' + this.config.format, params, callback);
+  this.request('PUT', '/memberships/' + id + '.json', params, callback);
 };
 
 /**
@@ -397,7 +334,7 @@ Redmine.prototype.update_project_membership = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#DELETE
  */
 Redmine.prototype.delete_project_membership = function(id, callback) {
-  this.request('DELETE', '/memberships/' + id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/memberships/' + id + '.json', {}, callback);
 };
 
 
@@ -407,7 +344,7 @@ Redmine.prototype.delete_project_membership = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueRelations#GET
  */
 Redmine.prototype.issue_relation_by_issue_id = function(id, callback) {
-  this.request('GET', '/issues/' + id + '/relations.' + this.config.format, {}, callback);
+  this.request('GET', '/issues/' + id + '/relations.json', {}, callback);
 };
 
 /**
@@ -415,7 +352,7 @@ Redmine.prototype.issue_relation_by_issue_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueRelations#POST
  */
 Redmine.prototype.create_issue_relation = function(id, params, callback) {
-  this.request('POST', '/issues/' + id + '/relations.' + this.config.format, params, callback);
+  this.request('POST', '/issues/' + id + '/relations.json', params, callback);
 };
 
 /**
@@ -423,7 +360,7 @@ Redmine.prototype.create_issue_relation = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueRelations#GET-2
  */
 Redmine.prototype.issue_relation_by_id = function(id, callback) {
-  this.request('GET', '/relations/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/relations/' + id + '.json', {}, callback);
 };
 
 /**
@@ -431,7 +368,7 @@ Redmine.prototype.issue_relation_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueRelations#DELETE
  */
 Redmine.prototype.delete_issue_relation = function(id, callback) {
- this.request('DELETE', '/relations/' + id + '.' + this.config.format, {}, callback);
+ this.request('DELETE', '/relations/' + id + '.json', {}, callback);
 };
 
 
@@ -441,7 +378,7 @@ Redmine.prototype.delete_issue_relation = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_News#GET
  */
 Redmine.prototype.news = function(callback) {
-  this.request('GET', '/news.' + this.config.format, {}, callback);
+  this.request('GET', '/news.json', {}, callback);
 };
 
 /**
@@ -449,7 +386,7 @@ Redmine.prototype.news = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_News#GET-2
  */
 Redmine.prototype.new_by_project_id = function(id, callback) {
-  this.request('GET', '/projects/' + id + '/news.' + this.config.format, {}, callback);
+  this.request('GET', '/projects/' + id + '/news.json', {}, callback);
 };
 
 
@@ -460,7 +397,7 @@ Redmine.prototype.new_by_project_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Versions#GET
  */
 Redmine.prototype.version_by_project_id = function(id, callback) {
-  this.request('GET', '/projects/' + id + '/versions.' + this.config.format, {}, callback);
+  this.request('GET', '/projects/' + id + '/versions.json', {}, callback);
 };
 
 /**
@@ -468,7 +405,7 @@ Redmine.prototype.version_by_project_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Versions#POST
  */
 Redmine.prototype.create_version = function(id, params, callback) {
-  this.request('POST', '/projects/' + id + '/versions.' + this.config.format, params, callback);
+  this.request('POST', '/projects/' + id + '/versions.json', params, callback);
 };
 
 /**
@@ -476,7 +413,7 @@ Redmine.prototype.create_version = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Versions#GET-2
  */
 Redmine.prototype.version_by_id = function(id, callback) {
-  this.request('GET', '/versions/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/versions/' + id + '.json', {}, callback);
 };
 
 /**
@@ -484,7 +421,7 @@ Redmine.prototype.version_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Versions#PUT
  */
 Redmine.prototype.update_version = function(id, params, callback) {
-  this.request('PUT', '/versions/' + id + '.' + this.config.format, params, callback);
+  this.request('PUT', '/versions/' + id + '.json', params, callback);
 };
 
 /**
@@ -492,7 +429,7 @@ Redmine.prototype.update_version = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Versions#DELETE
  */
 Redmine.prototype.delete_version = function(id, callback) {
-  this.request('DELETE', '/versions/' + id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/versions/' + id + '.json', {}, callback);
 };
 
 
@@ -502,7 +439,7 @@ Redmine.prototype.delete_version = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_WikiPages#Wiki-Pages
  */
 Redmine.prototype.wiki_by_project_id = function(id, callback) {
-  this.request('GET', '/projects/' + id + '/wiki/index.' + this.config.format, {}, callback);
+  this.request('GET', '/projects/' + id + '/wiki/index.json', {}, callback);
 };
 
 /**
@@ -510,7 +447,7 @@ Redmine.prototype.wiki_by_project_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_WikiPages#Getting-a-wiki-page
  */
 Redmine.prototype.wiki_by_title = function(id, title, params, callback) {
-  this.request('GET', '/projects/' + id + '/wiki/' + title + '.' + this.config.format, params, callback);
+  this.request('GET', '/projects/' + id + '/wiki/' + title + '.json', params, callback);
 };
 
 /**
@@ -518,7 +455,7 @@ Redmine.prototype.wiki_by_title = function(id, title, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_WikiPages#Getting-an-old-version-of-a-wiki-page
  */
 Redmine.prototype.wiki_history_by_title = function(id, title, version, params, callback) {
-  this.request('GET', '/projects/' + id + '/wiki/' + title + '/' + version + '.' + this.config.format, params, callback);
+  this.request('GET', '/projects/' + id + '/wiki/' + title + '/' + version + '.json', params, callback);
 };
 
 /**
@@ -526,7 +463,7 @@ Redmine.prototype.wiki_history_by_title = function(id, title, version, params, c
  * http://www.redmine.org/projects/redmine/wiki/Rest_WikiPages#Creating-or-updating-a-wiki-page
  */
 Redmine.prototype.ceate_wiki = function(id, title, params, callback) {
-  this.request('PUT', '/projects/' + id + '/wiki/' + title + '.' + this.config.format, params, callback);
+  this.request('PUT', '/projects/' + id + '/wiki/' + title + '.json', params, callback);
 };
 
 /**
@@ -534,7 +471,7 @@ Redmine.prototype.ceate_wiki = function(id, title, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#DELETE
  */
 Redmine.prototype.delete_wiki = function(id, title, callback) {
-  this.request('DELETE', '/projects/' + id + '/wiki/' + title + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/projects/' + id + '/wiki/' + title + '.json', {}, callback);
 };
 
 
@@ -544,7 +481,7 @@ Redmine.prototype.delete_wiki = function(id, title, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Queries#GET
  */
 Redmine.prototype.queries = function(callback) {
-  this.request('GET', '/queries.' + this.config.format, {}, callback);
+  this.request('GET', '/queries.json', {}, callback);
 };
 
 
@@ -555,7 +492,7 @@ Redmine.prototype.queries = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Attachments#GET
  */
 Redmine.prototype.attachment_by_id = function(id, callback) {
-  this.request('GET', '/attachments/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/attachments/' + id + '.json', {}, callback);
 };
 
 
@@ -565,7 +502,7 @@ Redmine.prototype.attachment_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueStatuses#GET
  */
 Redmine.prototype.issue_statuses = function(callback) {
-  this.request('GET', '/issue_statuses.' + this.config.format, {}, callback);
+  this.request('GET', '/issue_statuses.json', {}, callback);
 };
 
 
@@ -575,7 +512,7 @@ Redmine.prototype.issue_statuses = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Trackers#GET
  */
 Redmine.prototype.trackers = function(callback) {
-  this.request('GET', '/trackers.' + this.config.format, {}, callback);
+  this.request('GET', '/trackers.json', {}, callback);
 };
 
 
@@ -585,7 +522,7 @@ Redmine.prototype.trackers = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Enumerations#GET
  */
 Redmine.prototype.issue_priorities = function(callback) {
-  this.request('GET', '/enumerations/issue_priorities.' + this.config.format, {}, callback);
+  this.request('GET', '/enumerations/issue_priorities.json', {}, callback);
 };
 
 /**
@@ -593,7 +530,7 @@ Redmine.prototype.issue_priorities = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Enumerations#GET-2
  */
 Redmine.prototype.time_entry_activities = function(callback) {
-  this.request('GET', '/enumerations/time_entry_activities.' + this.config.format, {}, callback);
+  this.request('GET', '/enumerations/time_entry_activities.json', {}, callback);
 };
 
 
@@ -603,7 +540,7 @@ Redmine.prototype.time_entry_activities = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#GET
  */
 Redmine.prototype.issue_categories_by_project_id = function(id, callback) {
-  this.request('GET', '/projects/' + id + '/issue_categories.' + this.config.format, {}, callback);
+  this.request('GET', '/projects/' + id + '/issue_categories.json', {}, callback);
 };
 
 /**
@@ -611,7 +548,7 @@ Redmine.prototype.issue_categories_by_project_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#POST
  */
 Redmine.prototype.create_issue_category = function(id, params, callback) {
-  this.request('POST', '/projects/' + id + '/issue_categories.' + this.config.format, params, callback);
+  this.request('POST', '/projects/' + id + '/issue_categories.json', params, callback);
 };
 
 /**
@@ -619,7 +556,7 @@ Redmine.prototype.create_issue_category = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#GET-2
  */
 Redmine.prototype.issue_category_by_id = function(id, callback) {
-  this.request('GET', '/issue_categories/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/issue_categories/' + id + '.json', {}, callback);
 };
 
 /**
@@ -627,7 +564,7 @@ Redmine.prototype.issue_category_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#PUT
  */
 Redmine.prototype.update_issue_category = function(id, params, callback) {
-  this.request('PUT', '/issue_categories/' + id + '.' + this.config.format, params, callback);
+  this.request('PUT', '/issue_categories/' + id + '.json', params, callback);
 };
 
 /**
@@ -635,7 +572,7 @@ Redmine.prototype.update_issue_category = function(id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_IssueCategories#DELETE
  */
 Redmine.prototype.delete_issue_category = function(id, callback) {
-  this.request('DELETE', '/issue_categories/' + id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/issue_categories/' + id + '.json', {}, callback);
 };
 
 
@@ -645,7 +582,7 @@ Redmine.prototype.delete_issue_category = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Roles#GET
  */
 Redmine.prototype.roles = function(callback) {
-  this.request('GET', '/roles.' + this.config.format, {}, callback);
+  this.request('GET', '/roles.json', {}, callback);
 };
 
 /**
@@ -653,7 +590,7 @@ Redmine.prototype.roles = function(callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Roles#GET-2
  */
 Redmine.prototype.role_by_id = function(id, callback) {
-  this.request('GET', '/roles/' + id + '.' + this.config.format, {}, callback);
+  this.request('GET', '/roles/' + id + '.json', {}, callback);
 };
 
 
@@ -663,7 +600,7 @@ Redmine.prototype.role_by_id = function(id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Groups#groupsformat
  */
 Redmine.prototype.groups = function (callback) {
-  this.request('GET', '/groups.' + this.config.format, {}, callback);
+  this.request('GET', '/groups.json', {}, callback);
 };
 
 /**
@@ -671,7 +608,7 @@ Redmine.prototype.groups = function (callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Groups#POST
  */
 Redmine.prototype.create_group = function (params, callback) {
-  this.request('POST', '/groups.' + this.config.format, params, callback);
+  this.request('POST', '/groups.json', params, callback);
 };
 
 /**
@@ -679,7 +616,7 @@ Redmine.prototype.create_group = function (params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Groups#GET-2
  */
 Redmine.prototype.group_by_id = function (id, params, callback) {
-  this.request('GET', '/groups/' + id + '.' + this.config.format, params, callback);
+  this.request('GET', '/groups/' + id + '.json', params, callback);
 };
 
 /**
@@ -687,7 +624,7 @@ Redmine.prototype.group_by_id = function (id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Groups#PUT
  */
 Redmine.prototype.update_group = function (id, params, callback) {
-  this.request('PUT', '/groups/' + id + '.' + this.config.format, params, callback);
+  this.request('PUT', '/groups/' + id + '.json', params, callback);
 };
 
 /**
@@ -695,7 +632,7 @@ Redmine.prototype.update_group = function (id, params, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Groups#DELETE
  */
 Redmine.prototype.delete_group = function (id, callback) {
-  this.request('DELETE', '/groups/' + id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/groups/' + id + '.json', {}, callback);
 };
 
 /**
@@ -706,7 +643,7 @@ Redmine.prototype.add_user_to_group = function (group_id, user_id, callback) {
   var params = {
     user_id: user_id
   };
-  this.request('POST', '/groups/' + group_id + '/users.' + this.config.format, params, callback);
+  this.request('POST', '/groups/' + group_id + '/users.json', params, callback);
 };
 
 /**
@@ -714,7 +651,7 @@ Redmine.prototype.add_user_to_group = function (group_id, user_id, callback) {
  * http://www.redmine.org/projects/redmine/wiki/Rest_Groups#DELETE-2
  */
 Redmine.prototype.remove_user_from_group = function (group_id, user_id, callback) {
-  this.request('DELETE', '/groups/' + group_id + '/users/' + user_id + '.' + this.config.format, {}, callback);
+  this.request('DELETE', '/groups/' + group_id + '/users/' + user_id + '.json', {}, callback);
 };
 
 /////////////////////////////////////// REST API for Custom Fields (Alpha) ///////////////////////////////////////
@@ -723,7 +660,7 @@ Redmine.prototype.remove_user_from_group = function (group_id, user_id, callback
  * http://www.redmine.org/projects/redmine/wiki/Rest_CustomFields#GET
  */
 Redmine.prototype.custom_fields = function (callback) {
-  this.request('GET', '/custom_fields.' + this.config.format, {}, callback);
+  this.request('GET', '/custom_fields.json', {}, callback);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "wayne@zanran.me",
   "license": "GPL-3.0",
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "request": "^2.75.0"
   },
   "devDependencies": {
     "grunt": "^1.0.1",

--- a/test/redmine.test.js
+++ b/test/redmine.test.js
@@ -9,40 +9,36 @@ var Redmine = require('../lib/redmine');
 
 ///////////////////////////////////////////////////////////////
 var hostname = process.env.REDMINE_HOST || 'localhost';
-var config = {
-  apiKey: process.env.REDMINE_APIKEY || 'my-redmine-api-key'
-};
 
-describe('redmine.test.js', function() {
-  it('test-empty-confgi', function(done) {
+describe('Redmine constructor', function() {
+  it('should throw host not specified error when no host or config given', function(done) {
     try {
       new Redmine();
     } catch (e) {
-      assert.equal(e, 'Error: Invalidate hostname !');
-    }
-
-    done();
-  });
-
-  it('test-invalid-hostname-1', function(done) {
-    try {
-      new Redmine({});
-    } catch (e) {
-      assert.equal(e, 'Error: hostname should be a String !');
+      assert.equal(e, 'Error: host not specified!');
     }
     done();
   });
 
-  it('test-invalid-hostname-2', function(done) {
+  it('should throw invalid hostname error when host is invalid', function(done) {
     try {
       new Redmine(1);
     } catch (e) {
-      assert.equal(e, 'Error: hostname should be a String !');
+      assert.equal(e, 'Error: host should be a string or url object!');
     }
     done();
   });
 
-  it('test-invalid-options-2', function(done) {
+  it('should throw authentication missing error when no config given', function(done) {
+    try {
+      new Redmine('localhost');
+    } catch (e) {
+      assert.equal(e, 'Error: You should provide an API key or username & password !');
+    }
+    done();
+  });
+
+  it('should throw authentication missing error when API key and credentials missing', function(done) {
     try {
       new Redmine('localhost', {});
     } catch (e) {
@@ -51,40 +47,58 @@ describe('redmine.test.js', function() {
     done();
   });
 
-  it('test-invalid-options-format', function(done) {
+  it('should throw authentication missing error when password missing', function(done) {
+    var config = {
+      username: 'dummy-username'
+    };
     try {
-      new Redmine('localhost', {apiKey: process.env.REDMINE_APIKEY || 'my-redmine-api-key', 'format': 'html'});
+      new Redmine('localhost', {});
     } catch (e) {
-      assert.equal(e, 'Error: Redmine REST API only supports json and xml !');
+      assert.equal(e, 'Error: You should provide an API key or username & password !');
     }
     done();
   });
 
-  it('test-valid-options-format-xml', function(done) {
-    new Redmine('localhost', {apiKey: process.env.REDMINE_APIKEY || 'my-redmine-api-key', 'format': 'xml'});
-
+  it('should throw authentication missing error when username missing', function(done) {
+    var config = {
+      password: 'dummy-password'
+    };
+    try {
+      new Redmine('localhost', {});
+    } catch (e) {
+      assert.equal(e, 'Error: You should provide an API key or username & password !');
+    }
     done();
   });
 
-  it('test-valid-options-format-json', function(done) {
-    new Redmine('localhost', {apiKey: process.env.REDMINE_APIKEY || 'my-redmine-api-key', 'format': 'json'});
-
-    done();
-  });
-
-  it('test-valid-options', function(done) {
+  it('should not throw errors when host and api key given', function(done) {
+    var config = {
+      apiKey: process.env.REDMINE_APIKEY || 'my-redmine-api-key'
+    };
     new Redmine(hostname, config);
+    done();
+  });
 
+  it('should not throw errors when host and credentials given', function(done) {
+    var config = {
+      username: 'dummy-username',
+      password: 'dummy-password'
+    };
+    new Redmine(hostname, config);
     done();
   });
 
   it('test-valid-options-attributes', function(done) {
+    var config = {
+      apiKey:   'dummy-api-key',
+      username: 'dummy-username',
+      password: 'dummy-password'
+    };
     var redmine = new Redmine(hostname, config);
 
-    assert.equal(redmine.apiKey, config.apiKey);
-    assert.equal(redmine.host, hostname);
-    assert.equal(redmine.username, undefined);
-    assert.equal(redmine.password, undefined);
+    assert.equal(redmine.apiKey,   'dummy-api-key');
+    assert.equal(redmine.username, 'dummy-username');
+    assert.equal(redmine.password, 'dummy-password');
 
     done();
   });


### PR DESCRIPTION
By using [request](https://github.com/request/request/blob/master/request.js#L457) instead of node's built in http module this library now supports HTTPS, fixing #2.

I also:
- removed the 'format' configuration, which didn't work anyway (see #4);
- improved the readability of the tests;
- removed a bunch of helper functions that are already implemented in the request library.
 