### PR TITLE
Add `params` arg to `membership_by_project_id`

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -337,8 +337,8 @@ Redmine.prototype.delete_time_entry = function(id, callback) {
  * Returns a paginated list of the project memberships. :project_id can be either the project numerical id or the project identifier.
  * http://www.redmine.org/projects/redmine/wiki/Rest_Memberships#GET
  */
-Redmine.prototype.membership_by_project_id = function(id, callback) {
-  this.request('GET', '/projects/' + id + '/memberships.json', {}, callback);
+Redmine.prototype.membership_by_project_id = function(id, params, callback) {
+  this.request('GET', '/projects/' + id + '/memberships.json', params, callback);
 };
 
 /**


### PR DESCRIPTION
#### Because:

* It's not documented in the API docs, but the
  `/projects/:project_id/memberships.:format` endpoint accepts `limit`
  and `offset` parameters, which default to `25` and `0` respectively.
* If a project has more than 25 members there's currently no way of
  retrieving those via the current `membership_by_project_id` function.

Fixes #14