### PR TITLE
Support for uploading attachments

### DIFF
--- a/lib/redmine.js
+++ b/lib/redmine.js
@@ -86,6 +86,7 @@ Redmine.prototype.encodeURL = function(path, params) {
  * request - request url from Redmine
  */
 Redmine.prototype.request = function(method, path, params, callback) {
+  var isUpload = method == '/uploads.json';
   var opts = {
     method: method,
     qs: method === 'GET' ? params : undefined,
@@ -94,7 +95,7 @@ Redmine.prototype.request = function(method, path, params, callback) {
       'Content-Type': 'application/json'
     },
     // auth: { user: this.username, pass: this.password },
-    json: true
+    json: !isUpload
   };
 
   // impersonate to a login user
@@ -122,7 +123,7 @@ Redmine.prototype.request = function(method, path, params, callback) {
       return callback(JSON.stringify(msg));
     }
 
-    return callback(null, body);
+    return callback(null, isUpload ? JSON.parse(body) : body);
   });
 };
 
@@ -703,11 +704,10 @@ Redmine.prototype.custom_fields = function (callback) {
  * upload a file to redmine
  * http://www.redmine.org/projects/redmine/wiki/Rest_WikiPages#Attaching-files
  */
-/*
-Redmine.prototype.upload = function(filepath, callback) {
-  this.request('POST', '/uploads.json', {}, callback);
+
+Redmine.prototype.upload = function (content, callback) {
+  this.request('POST', '/uploads.json', content, callback);
 };
-*/
 
 ////////////////////////////////////////////////////////////////////////////////////////
 module.exports = Redmine;


### PR DESCRIPTION
I know it's not a nice practice to hardcode the method url in the request function, but somehow we must distinguish between uploads and non-upload api calls. (And I did not want one more function parameter)
The problem is that the "json" option sets both the request and the response to json, wich is bad for file uploading.
Therefore we need to turn it off for uploading, and turn it back on for reading out the token from the response. If you find a better way to structure this change, go ahead and fix it! ;)
Maybe an const enum with the api urls could be a nicer solution.